### PR TITLE
[DOCS-9858] Minor copy edits for the managed controller CasC files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-tmp
+#Ignore auto-generated files and directories
+.DS_Store
+.idea
+.vscode
+*.bkp
+*.dtmp
+*.save

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 CloudBees
+Copyright (c) 2024 CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![gitleaks badge](https://img.shields.io/badge/protected%20by-gitleaks-blue)](https://github.com/zricethezav/gitleaks#pre-commit) [![gitsecrets](https://img.shields.io/badge/protected%20by-gitsecrets-blue)](https://github.com/awslabs/git-secrets)
 
-Repository for [Configuration as Code (CasC) for Controllers](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-controller/).
+This repository is for [Configuration as Code (CasC) for controllers](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-controller/).
 
-Plugins and plugin catalogs curated with [casc-plugin-dependency-calculation](https://github.com/kyounger/casc-plugin-dependency-calculation).
+Plugins and plugin catalogs are curated with the [CloudBees CasC Plugin Catalog and Transitive Dependencies Calculator](https://github.com/kyounger/casc-plugin-dependency-calculation).
 
-Inheritance Merge strategies are explained [here](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-controller/advanced#_configuring_bundle_inheritance_with_casc).
+Inheritance merge strategies are explained in the [CloudBees CI documentation](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-controller/advanced#_configuring_bundle_inheritance_with_casc).
 
-This bundle is tested and validated against `chart` version from `main.yaml` in [CloudBees CI Add-on for AWS EKS](https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon)
+This bundle is tested and validated against the `chart` version from the `main.yaml` in [CloudBees CI add-on for Amazon EKS blueprints](https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon).

--- a/bp02.ha/bundle.yaml
+++ b/bp02.ha/bundle.yaml
@@ -1,6 +1,6 @@
 apiVersion: "1"
 id: "modern.ha"
-description: "Casc Bundle for HA Controllers. It is tested for CB EKS Add-ons blueprints 02"
+description: "CasC bundle for HA controllers. It is tested for the CloudBees CI blueprint add-on: At scale."
 version: "1"
 parent: "bp02.parent"
 allowCapExceptions: true

--- a/bp02.ha/catalog/2.426.3.3.yaml
+++ b/bp02.ha/catalog/2.426.3.3.yaml
@@ -1,11 +1,11 @@
-#NOTE: This plugin catalog contains parent's description + own description (e.g mock-load-builder)
-#Reason: Child plugin catalog overrides parent ones
+#NOTE: This plugin catalog contains the parent bundle's description plus its own description (for example, the mock-load-builder plugin)
+#Reason: Child plugin catalog overrides the parent plugin catalog
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Plugin Catalog"
+displayName: "My plugin catalog"
 configurations:
-  - description: "These are Non-CAP plugins for version 2.426.3.3"
+  - description: "These plugins are not included in the CloudBees Assurance Program (CAP) for CloudBees CI version 2.426.3.3."
     prerequisites:
       productVersion: "[2.426.3.3]"
     includePlugins:

--- a/bp02.none-ha/bundle.yaml
+++ b/bp02.none-ha/bundle.yaml
@@ -1,6 +1,6 @@
 apiVersion: "1"
 id: "modern.none-ha"
-description: "Casc Bundle for None HA Controllers. It is tested for CB EKS Add-ons blueprints 02"
+description: "CasC bundle for non-HA controllers. It is tested for the CloudBees CI blueprint add-on: At scale."
 version: "1"
 parent: "bp02.parent"
 allowCapExceptions: true

--- a/bp02.none-ha/items/items-root.yaml
+++ b/bp02.none-ha/items/items-root.yaml
@@ -34,7 +34,7 @@ items:
                 }
             }
         }
-  description: 'This pipeline demostrate the usage of https://plugins.jenkins.io/artifact-manager-s3/ across pipelines'
+  description: 'This pipeline demonstrates the usage of https://plugins.jenkins.io/artifact-manager-s3/ across pipelines.'
   disabled: false
   displayName: downstream-artifact
   resumeBlocked: false
@@ -110,7 +110,7 @@ items:
             }
         }
   disabled: false
-  description: 'This pipeline demostrate the usage of https://plugins.jenkins.io/artifact-manager-s3/ in the same pipeline'
+  description: 'This pipeline demonstrates the usage of https://plugins.jenkins.io/artifact-manager-s3/ in the same pipeline.'
 - kind: pipeline
   name: ws-cache
   concurrentBuild: true
@@ -154,5 +154,5 @@ items:
                 }
             }
         }
-  description: 'This pipeline demostrate the usage of https://docs.cloudbees.com/docs/cloudbees-ci/latest/pipelines/cloudbees-cache-step'
+  description: 'This pipeline demonstrates the usage of https://docs.cloudbees.com/docs/cloudbees-ci/latest/pipelines/cloudbees-cache-step.'
   disabled: false

--- a/bp02.parent/bundle.yaml
+++ b/bp02.parent/bundle.yaml
@@ -1,6 +1,6 @@
 apiVersion: "1"
 id: "bp02.parent"
-description: "Parent Casc Bundle. It is tested for CB EKS Add-ons blueprints 02"
+description: "Parent CasC bundle. It is tested for the CloudBees CI blueprint add-on: At scale."
 version: "1"
 jcasc:
   - jcasc

--- a/bp02.parent/catalog/2.426.3.3.yaml
+++ b/bp02.parent/catalog/2.426.3.3.yaml
@@ -1,9 +1,9 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Plugin Catalog"
+displayName: "My plugin catalog"
 configurations:
-  - description: "These are Non-CAP plugins for version 2.426.3.3"
+  - description: "These plugins are not included in the CloudBees Assurance Program (CAP) for CloudBees CI version 2.426.3.3."
     prerequisites:
       productVersion: "[2.426.3.3]"
     includePlugins:

--- a/bp02.parent/variables/variables.yaml
+++ b/bp02.parent/variables/variables.yaml
@@ -1,4 +1,4 @@
 variables:
-  #It requires to be updated in case var suffix is provided in tf files (e.g cbci-bp02-<YOUR-SUFFIX>-s3)
+  #You must update the variable in case a variable suffix is provided in the .tf files (for example, cbci-bp02-<YOUR-SUFFIX>-s3)
   - cbci_s3: cbci-bp02-s3
 


### PR DESCRIPTION
Minor copy edits for consistency with the recently revised CloudBees CI add-on for Amazon EKS blueprints.